### PR TITLE
計算機能追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,10 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <version>1.18.30</version>
       <scope>provided</scope>
   </dependency>
-      
+  
   </dependencies>
 
   <build>

--- a/src/main/java/com/example/demo/controller/DashboardController.java
+++ b/src/main/java/com/example/demo/controller/DashboardController.java
@@ -10,6 +10,9 @@ import java.util.List;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import com.example.demo.service.NutritionService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class DashboardController {
@@ -17,18 +20,39 @@ public class DashboardController {
     @Autowired
     private NutritionRepository nutritionRepository;
 
+    @Autowired
+    private NutritionService nutritionService;
+
     @GetMapping("/dashboard")
     public String getDashboard(Model model) {
         List<Nutrition> foods = nutritionRepository.findAll();
         model.addAttribute("foods", foods);
 
+        
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication != null && authentication.getPrincipal() instanceof UserDetails) {
             UserDetails userDetails = (UserDetails) authentication.getPrincipal();
             model.addAttribute("username", userDetails.getUsername());
         }
-        
+        return "dashboard";
+    }
+
+    @PostMapping("/dashboard")
+    public String postDashboard(@RequestParam String food, @RequestParam double grams, Model model) {
+        Nutrition selectedNutrition = nutritionService.getNutritionByFoodName(food);
+        Nutrition calculatedNutrition = nutritionService.calculateNutritionForGrams(selectedNutrition, grams);
+        model.addAttribute("selectedNutrition", calculatedNutrition);
+
+        List<Nutrition> foods = nutritionRepository.findAll();
+        model.addAttribute("foods", foods);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetails) {
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            model.addAttribute("username", userDetails.getUsername());
+        }
+
         return "dashboard";
     }
 }

--- a/src/main/java/com/example/demo/controller/NutritionController.java
+++ b/src/main/java/com/example/demo/controller/NutritionController.java
@@ -1,0 +1,25 @@
+package com.example.demo.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import com.example.demo.model.Nutrition;
+import com.example.demo.service.NutritionService;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+
+@RestController
+@RequestMapping("/nutrition")
+public class NutritionController {
+
+    @Autowired
+    private NutritionService nutritionService;
+
+    @GetMapping("/calculate")
+    public Nutrition calculateNutrition(@RequestParam String foodName, @RequestParam double grams) {
+        Nutrition nutrition = nutritionService.getNutritionByFoodName(foodName);
+        return nutritionService.calculateNutritionForGrams(nutrition, grams);
+    }
+}

--- a/src/main/java/com/example/demo/repository/NutritionRepository.java
+++ b/src/main/java/com/example/demo/repository/NutritionRepository.java
@@ -4,4 +4,5 @@ import com.example.demo.model.Nutrition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NutritionRepository extends JpaRepository<Nutrition, Long> {
+    Nutrition findByFoodName(String foodName);
 }

--- a/src/main/java/com/example/demo/service/NutritionService.java
+++ b/src/main/java/com/example/demo/service/NutritionService.java
@@ -1,0 +1,27 @@
+package com.example.demo.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import com.example.demo.repository.NutritionRepository;
+import com.example.demo.model.Nutrition;
+
+
+@Service
+public class NutritionService {
+
+    @Autowired
+    private NutritionRepository nutritionRepository;
+
+    public Nutrition getNutritionByFoodName(String foodName) {
+        return nutritionRepository.findByFoodName(foodName);
+    }
+
+    public Nutrition calculateNutritionForGrams(Nutrition nutrition, double grams) {
+        nutrition.setEnergy(nutrition.getEnergy() * grams / 100);
+        nutrition.setProtein(nutrition.getProtein() * grams / 100);
+        nutrition.setFat(nutrition.getFat() * grams / 100);
+        nutrition.setCholesterol(nutrition.getCholesterol() * grams / 100);
+        nutrition.setCarbohydrates(nutrition.getCarbohydrates() * grams / 100);
+        return nutrition;
+    }
+}

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -18,14 +18,24 @@
     <form action="#" method="post">
         <label>Food:</label>
         <select name="food">
-            <option th:each="food : ${foods}" th:value="${food.getFoodName()}" th:text="${food.getFoodName()}"></option>
+            <option th:each="food : ${foods}" th:if="${food != null}" th:value="${food.getFoodName}" th:text="${food.getFoodName}"></option>
         </select>
         <label>Grams:</label>
         <input type="number" name="grams" placeholder="Enter weight in grams" />
         <label>Date:</label>
         <input type="date" name="date" />
         <input type="submit" value="Add" />
+        <input type="hidden" name="_csrf" th:value="${_csrf.token}"/>
     </form>
+
+    <div th:if="${selectedNutrition != null}">
+        <h4>選択した食品の栄養素情報 (100g当たり)</h4>
+        <p><strong>カロリー(kcal):</strong> <span th:text="${selectedNutrition.energy}"></span></p>
+        <p><strong>タンパク質 (g):</strong> <span th:text="${selectedNutrition.protein}"></span></p>
+        <p><strong>脂質 (g):</strong> <span th:text="${selectedNutrition.fat}"></span></p>
+        <p><strong>コレステロール (mg):</strong> <span th:text="${selectedNutrition.cholesterol}"></span></p>
+        <p><strong>炭水化物 (g):</strong> <span th:text="${selectedNutrition.carbohydrates}"></span></p>
+    </div>
     
 
     <table>
@@ -61,3 +71,4 @@
 
 </body>
 </html>
+}


### PR DESCRIPTION
java/issue-7と同じ内容です。

データベースにある食品栄養素を利用して、
100グラム辺りの栄養素をダッシュボードに出力するようにしました。
出力の位置は仮でフォームの下に置きました。
計算機能を追加するという目的で作成しましたので、配置場所には意味はありません。
これにより、栄養素を計算し今後の課題である1日の栄養素出力と履歴の出力に活用できると思います。

変更点は
dashboard.html
100グラム当たりの栄養素を出力するように作成。
カロリー、たんぱく質、脂質、コレステロール、炭水化物

DashboardController.java
ユーザーが入力した食品名とグラム数に基づいて栄養情報を取得し、それをダッシュボードビューに表示するように追加

NutritionController.java
食品名に基づいて栄養情報を取得し指定されたグラム数に基づいて栄養情報を調整。
調整された栄養情報をAPIの呼び出し元にレスポンスとして返すように追加。

NutritionService.java
栄養情報をデータベースから取得するためにリポジトリクラスを参照し、
Nutritionオブジェクトをデータベースから取得し、
各栄養素を100グラム当たりで計算するように追加。

NutritionRepository.java
食品名に基づいてnutritionエンティティを検索するメゾッドを追加。

よろしくお願いいたします。