### PR TITLE
グラム数未入力のエラー、履歴に食品名表示

### DIFF
--- a/src/main/java/com/example/demo/controller/DashboardController.java
+++ b/src/main/java/com/example/demo/controller/DashboardController.java
@@ -99,6 +99,12 @@ public class DashboardController {
         List<NutritionDailySummary> nutritionSummaryList = nutritionService.getPastNutritionDailySummaryForUser(username);
         logger.info("Fetched {} nutrition summary records for user: {}", nutritionSummaryList.size(), username);
 
+        if (nutritionSummaryList == null) {
+            logger.error("nutritionSummaryList is null.");
+            return;
+        }
+
+
         // nullのオブジェクトをフィルタリング
         nutritionSummaryList = nutritionSummaryList.stream().filter(Objects::nonNull).collect(Collectors.toList());
 

--- a/src/main/java/com/example/demo/model/Nutrition.java
+++ b/src/main/java/com/example/demo/model/Nutrition.java
@@ -35,3 +35,5 @@ public class Nutrition {
     private Double cholesterol = 0.0;
     @Column(name = "炭水化物")
     private Double carbohydrates = 0.0;
+
+}

--- a/src/main/java/com/example/demo/repository/NutritionHistoryRepository.java
+++ b/src/main/java/com/example/demo/repository/NutritionHistoryRepository.java
@@ -23,7 +23,7 @@ public interface NutritionHistoryRepository extends JpaRepository<NutritionHisto
     @Query("SELECT " +
        "MIN(n.id) AS id, " +
        "n.date AS date, " +
-       "string_agg(n.foodName, ', ') AS foodNames, " + // foodNamesをカンマで区切って連結
+       "string_agg(COALESCE(n.foodName, ''), ', ') AS foodName,"+
        "SUM(n.grams) AS grams, " +
        "SUM(n.energy) AS energy, " +
        "SUM(n.protein) AS protein, " +

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -23,7 +23,7 @@
             <option th:each="food : ${foods}" th:if="${food != null}" th:value="${food.getFoodName}" th:text="${food.getFoodName}"></option>
         </select>
         <label>Grams:</label>
-        <input type="number" name="grams" placeholder="Enter weight in grams" />
+        <input type="number" name="grams" placeholder="Enter weight in grams" required/>
         <label>Date:</label>
         <input type="date" name="date" />
         <input type="submit" value="Add" />


### PR DESCRIPTION
グラムを誤って未入力の際にエラーになってしまう、履歴に食品名が表示されないというエラーが発生していたので、修正しました。
この修正により、エラーを防ぎ、取得した栄養素を把握することができます。


グラム数未入力エラーの修正点は
dashboard.html
グラム入力の部分に```required```を追加し入力を必須に変更

DashboardController.java
食品名がnullの場合の対処を追加

食品名表示修正点は
NutritionHistory.java
COALESCE関数で与えられた引数の中で最初のNULLでない値を返すように変更

よろしくお願いいたします。